### PR TITLE
Fixing build problems

### DIFF
--- a/.github/workflows/maven-build.yml
+++ b/.github/workflows/maven-build.yml
@@ -26,7 +26,7 @@ jobs:
         key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
         restore-keys: ${{ runner.os }}-m2
     - name: Build with Maven
-      run: mvn -B package --file pom.xml
+      run: mvn -B package --settings ./.mvn/unblock-mirrors.xml --file pom.xml 
     - name: Copy artifacts
       run: mkdir staging && cp target/*.jar staging  && cp target/*.zip staging
     - uses: actions/upload-artifact@v2

--- a/.mvn/unblock-mirrors.xml
+++ b/.mvn/unblock-mirrors.xml
@@ -9,5 +9,55 @@
             <url>http://genesis.ugent.be/maven2</url>
             <blocked>false</blocked>
         </mirror>
+        <!-- genesis depends on these -->
+        <mirror>
+            <id>ebi-repo-http-unblocker</id>
+            <mirrorOf>ebi-repo</mirrorOf>
+            <url>http://www.ebi.ac.uk/~maven/m2repo</url>
+            <blocked>false</blocked>
+        </mirror>
+        <mirror>
+            <id>pst-release-unblocker</id>
+            <mirrorOf>pst-release</mirrorOf>
+            <url>http://www.ebi.ac.uk/Tools/maven/repos/content/repositories/pst-release</url>
+            <blocked>false</blocked>
+        </mirror>
+        <mirror>
+            <id>pst-snapshots-unblocker</id>
+            <mirrorOf>pst-snapshots</mirrorOf>
+            <url>http://www.ebi.ac.uk/Tools/maven/repos/content/repositories/pst-snapshots</url>
+            <blocked>false</blocked>
+        </mirror>
+        <mirror>
+            <id>ebi-repo-snapshots-http-unblocker</id>
+            <mirrorOf>ebi-repo-snapshots</mirrorOf>
+            <url>http://www.ebi.ac.uk/~maven/m2repo_snapshots</url>
+            <blocked>false</blocked>
+        </mirror>
+
+        <mirror>
+            <id>com.springsource.repository.bundles.release-http-unblocker</id>
+            <mirrorOf>com.springsource.repository.bundles.release</mirrorOf>
+            <url>http://repository.springsource.com/maven/bundles/release</url>
+            <blocked>false</blocked>
+        </mirror>
+        <mirror>
+            <id>com.springsource.repository.bundles.external-http-unblocker</id>
+            <mirrorOf>com.springsource.repository.bundles.external</mirrorOf>
+            <url>http://repository.springsource.com/maven/bundles/external</url>
+            <blocked>false</blocked>
+        </mirror>
+        <mirror>
+            <id>maven repository-http-unblocker</id>
+            <mirrorOf>maven repository</mirrorOf>
+            <url>http://download.java.net/maven/1/</url>
+            <blocked>false</blocked>
+        </mirror>
+        <mirror>
+            <id>codehaus-http-unblocker</id>
+            <mirrorOf>codehaus</mirrorOf>
+            <url>http://repository.codehaus.org/</url>
+            <blocked>false</blocked>
+        </mirror>
     </mirrors>
 </settings>

--- a/.mvn/unblock-mirrors.xml
+++ b/.mvn/unblock-mirrors.xml
@@ -1,0 +1,13 @@
+<settings xmlns="http://maven.apache.org/SETTINGS/1.2.0"
+          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.2.0 http://maven.apache.org/xsd/settings-1.2.0.xsd">
+    <mirrors>
+        <mirror>
+            <!-- need to unblock insecure http connection for newer maven -->
+            <id>genesis-maven2-repository-http-unblocker</id>
+            <mirrorOf>genesis-maven2-repository</mirrorOf>
+            <url>http://genesis.ugent.be/maven2</url>
+            <blocked>false</blocked>
+        </mirror>
+    </mirrors>
+</settings>

--- a/pom.xml
+++ b/pom.xml
@@ -343,6 +343,20 @@
             <layout>default</layout>
         </repository>
 
+        <!-- depending repos, necessary as long as genesis uses them via http -->
+        <repository>
+            <id>pst-release</id>
+            <name>The EBI Maven 2 Nexus pst-release repository</name>
+            <url>https://www.ebi.ac.uk/Tools/maven/repos/content/repositories/pst-release/</url>
+        </repository>
+        
+        <repository>
+            <id>pst-snapshots</id>
+            <name>The EBI Maven 2 Nexus pst-snapshots repository</name>
+            <url>https://www.ebi.ac.uk/Tools/maven/repos/content/repositories/pst-snapshots/</url>
+        </repository>
+        
+        
 		<!-- local files for the PD parser -->
 		<repository>
 			<id>pia-shipped-repo</id>

--- a/pom.xml
+++ b/pom.xml
@@ -343,20 +343,6 @@
             <layout>default</layout>
         </repository>
 
-        <!-- depending repos, necessary as long as genesis uses them via http -->
-        <repository>
-            <id>pst-release</id>
-            <name>The EBI Maven 2 Nexus pst-release repository</name>
-            <url>https://www.ebi.ac.uk/Tools/maven/repos/content/repositories/pst-release/</url>
-        </repository>
-        
-        <repository>
-            <id>pst-snapshots</id>
-            <name>The EBI Maven 2 Nexus pst-snapshots repository</name>
-            <url>https://www.ebi.ac.uk/Tools/maven/repos/content/repositories/pst-snapshots/</url>
-        </repository>
-        
-        
 		<!-- local files for the PD parser -->
 		<repository>
 			<id>pia-shipped-repo</id>

--- a/pom.xml
+++ b/pom.xml
@@ -325,7 +325,7 @@
         <repository>
             <id>nexus-ebi-release-repo</id>
             <name>The EBI Maven 2 Nexus release repository</name>
-            <url>http://www.ebi.ac.uk/Tools/maven/repos/content/groups/ebi-repo/</url>
+            <url>https://www.ebi.ac.uk/Tools/maven/repos/content/groups/ebi-repo/</url>
         </repository>
         
         <repository>


### PR DESCRIPTION
Maven is stricter regarding insecure HTTP repos.
Fixing this by changing to HTTPS repos and putting dependencies, which do not have HTTPS, into exceptions.